### PR TITLE
5.0.0_SKS_29 UUID-4 constraint fix

### DIFF
--- a/input/fsh/MedComIdentifierExtension.fsh
+++ b/input/fsh/MedComIdentifierExtension.fsh
@@ -12,7 +12,7 @@ Id: medcom-assigned-identifier
 Title: "AssignedIdentifier"
 Description: "An UUID identifier assigned by an organisation"
 * value 1..
-  * ^short = "The value is a UUID identifier version 4." // (Not sure about this line, I think it should work?
+  * ^short = "The value is a UUID identifier version 4." 
   * obeys medcom-uuidv4
 * assigner 1..
 * assigner ^short = "A reference to the organization that initially added the identifier."


### PR DESCRIPTION
Correct constraint placement and FHIRPath expression in MedComAssignedIdentifier.
Moved the medcom-uuidv4 constraint to the root of the profile and updated the expression to self.value.matches(...).

This ensures the constraint is evaluated in the correct context when used inside extensions, and avoids validation issues in Simplifier’s Modern Validator.